### PR TITLE
Update Lombok for Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <mockito-junit-jupiter.version>3.3.3</mockito-junit-jupiter.version>
         <hamcrest.version>2.2</hamcrest.version>
 
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.38</lombok.version>
         <apache.commons-lang3.version>3.10</apache.commons-lang3.version>
         <apache.commons-text.version>1.8</apache.commons-text.version>
         <validation-api.version>2.0.0.Final</validation-api.version>


### PR DESCRIPTION
## Summary
- update Lombok dependency to 1.18.38 for Java 21 compatibility

## Testing
- `mvn -version`
- `mvn -pl java-design-patterns -am test` *(fails: Plugin not found due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684c5caf6c04832e947e0a46f4930c33