### PR TITLE
Fix validation imports

### DIFF
--- a/java-custom-validation/src/main/java/com/froyo/customvalidation/AirlineValidator.java
+++ b/java-custom-validation/src/main/java/com/froyo/customvalidation/AirlineValidator.java
@@ -3,8 +3,8 @@ package com.froyo.customvalidation;
 import com.froyo.customvalidation.constraints.AirlineConstraint;
 import org.apache.commons.lang3.StringUtils;
 
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 import java.util.List;
 
 import static com.froyo.common.codevalues.AIRLINE.*;

--- a/java-custom-validation/src/main/java/com/froyo/customvalidation/constraints/AirlineConstraint.java
+++ b/java-custom-validation/src/main/java/com/froyo/customvalidation/constraints/AirlineConstraint.java
@@ -2,8 +2,8 @@ package com.froyo.customvalidation.constraints;
 
 import com.froyo.customvalidation.AirlineValidator;
 
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
+import javax.validation.Constraint;
+import javax.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/java-custom-validation/src/main/java/com/froyo/model/dto/TripDTO.java
+++ b/java-custom-validation/src/main/java/com/froyo/model/dto/TripDTO.java
@@ -1,7 +1,7 @@
 package com.froyo.model.dto;
 
 import com.froyo.customvalidation.constraints.AirlineConstraint;
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 
 public class TripDTO {
 


### PR DESCRIPTION
## Summary
- use `javax.validation` instead of `jakarta.validation` for custom validations

## Testing
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684c61987564832e813343477a4e1af5